### PR TITLE
feat: implement Web Share API for Slack sharing

### DIFF
--- a/src/components/BookDisplay.tsx
+++ b/src/components/BookDisplay.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import { BookInfo } from '@/types'
-import { generateShareText, copyToClipboard, shareToX, shareToSlack } from '@/lib/share'
+import { generateShareText, copyToClipboard, shareToX, shareToSlack, shareWithWebAPI } from '@/lib/share'
 import { useState } from 'react'
 
 interface BookDisplayProps {
@@ -31,6 +31,23 @@ export function BookDisplay({ bookInfo }: BookDisplayProps) {
   const handleShareSlack = () => {
     const shareText = generateShareText(bookInfo)
     shareToSlack(shareText)
+  }
+
+  const handleWebShare = async () => {
+    try {
+      const shareText = generateShareText(bookInfo)
+      await shareWithWebAPI({
+        title: 'このページをSlackで共有',
+        text: shareText,
+        url: window.location.href,
+      })
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message)
+      } else {
+        console.error('共有に失敗:', error)
+      }
+    }
   }
 
   return (
@@ -114,6 +131,13 @@ export function BookDisplay({ bookInfo }: BookDisplayProps) {
             className="px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded transition-colors"
           >
             💬 Slack で共有
+          </button>
+          
+          <button
+            onClick={handleWebShare}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded transition-colors"
+          >
+            📱 Slackに共有
           </button>
         </div>
       </div>

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -35,3 +35,22 @@ export function shareToSlack(text: string): void {
   const url = `https://slack.com/intl/ja-jp/shared?text=${encodeURIComponent(text)}`
   window.open(url, '_blank')
 }
+
+export async function shareWithWebAPI(shareData: {
+  title?: string
+  text?: string  
+  url?: string
+}): Promise<void> {
+  if (!navigator.share) {
+    throw new Error('この機能はお使いのブラウザではサポートされていません。')
+  }
+  
+  try {
+    await navigator.share(shareData)
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return // User cancelled - not an error
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
Add Web Share API functionality that allows users to share content to Slack and other apps using the native OS share menu on mobile browsers.

## Changes:
- Add shareWithWebAPI function in src/lib/share.ts with browser support detection and error handling
- Add Web Share button in BookDisplay component with green styling
- Handle user cancellation gracefully (AbortError)
- Include proper fallback messaging for unsupported browsers

Fixes #3

Generated with [Claude Code](https://claude.ai/code)